### PR TITLE
added blazer group id param to queries variable

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -263,7 +263,7 @@ module Blazer
             []
           end
 
-        @queries = Blazer::Query.named.select(:id, :name, :creator_id, :statement)
+        @queries = Blazer::Query.named.select(:id, :name, :creator_id, :blazer_group_id, :statement)
         @queries = @queries.includes(:creator) if Blazer.user_class
 
         if blazer_user && params[:filter] == "mine"


### PR DESCRIPTION
**Issue**

blazer_group_id param was not being passed in to @queries, which threw a missing attribute error. Not originally caught because the error was not showing for all users, presumably an if statement was being hit each time which did not require an attribute for users used while testing.

**Solution**

Added in the blazer_group_id attribute.
